### PR TITLE
Cleanup

### DIFF
--- a/evolve_inner_core/src/array.rs
+++ b/evolve_inner_core/src/array.rs
@@ -40,6 +40,18 @@ pub fn evolve_array_get(array: &EvolveArray, index: usize) -> Object {
     *(array.get(adjusted_index).unwrap_or_default())
 }
 
+#[no_mangle]
+#[inline(always)]
+fn evolve_array_size(array: &EvolveArray) -> usize {
+    array.len()
+}
+
+#[no_mangle]
+#[inline(always)]
+fn evolve_array_capacity(array: &EvolveArray) -> usize {
+    array.capacity()
+}
+
 /// adjust index from 1-index to 0-indexed
 /// 0 case is best handled above
 /// get: should be fine because it will be out of range and this null

--- a/evolve_inner_core/src/array_tests.rs
+++ b/evolve_inner_core/src/array_tests.rs
@@ -1,6 +1,21 @@
 use super::*;
 
 #[test]
+fn test_new() {
+    let a = evolve_array_literal(10);
+    assert_eq!(10, a.capacity());
+    assert_eq!(0, a.len());
+    assert_eq!(10, evolve_array_capacity(a));
+    assert_eq!(0, evolve_array_size(a));
+
+    let a = evolve_array_literal(0);
+    assert_eq!(8, a.capacity());
+    assert_eq!(0, a.len());
+    assert_eq!(8, evolve_array_capacity(a));
+    assert_eq!(0, evolve_array_size(a));
+}
+
+#[test]
 fn test_get_oob() {
     let a = evolve_array_literal(1);
     let b = evolve_array_get(a, 100);

--- a/evolve_inner_core/src/intrinsic.rs
+++ b/evolve_inner_core/src/intrinsic.rs
@@ -44,8 +44,8 @@ pub const fn evolve_intrinsic_is_false(value: Object) -> bool {
 }
 
 mod indexable {
+    use crate::class_ids::{ARRAY_CLASS_ID, INT_CLASS_ID, TUPLE_CLASS_ID};
     use crate::object::Object;
-    use crate::class_ids::{ARRAY_CLASS_ID, TUPLE_CLASS_ID, INT_CLASS_ID};
 
     #[inline(always)]
     #[export_name = "evolve.intrinsic2.get"]
@@ -55,8 +55,8 @@ mod indexable {
         }
 
         match value.class_id() {
-            TUPLE_CLASS_ID => { value.tuple_get(index.extract_i64() as usize)},
-            ARRAY_CLASS_ID => { value.array_get(index.extract_i64() as usize)},
+            TUPLE_CLASS_ID => value.tuple_get(index.extract_i64() as usize),
+            ARRAY_CLASS_ID => value.array_get(index.extract_i64() as usize),
             _ => Object::intrinsic_fail(),
         }
     }

--- a/evolve_inner_core/src/intrinsic.rs
+++ b/evolve_inner_core/src/intrinsic.rs
@@ -43,25 +43,24 @@ pub const fn evolve_intrinsic_is_false(value: Object) -> bool {
     !value.is_true()
 }
 
-// mod indexable {
-//     use crate::object::Object;
-//     use crate::class_ids::{ARRAY_CLASS_ID, TUPLE_CLASS_ID, INT_CLASS_ID};
-//
-//     #[inline(always)]
-//     #[export_name = "evolve.intrinsic2.get"]
-//     fn evolve_intrinsic_get(value: Object, index: Object) -> Object {
-//         if index.tag() != INT_CLASS_ID as u64 {
-//             return Object::null();
-//         }
-//
-//         match value.class_id() {
-//             TUPLE_CLASS_ID => { value.tuple_get(index.extract_i64() as usize)},
-//             ARRAY_CLASS_ID => { value.array_get(index.extract_i64() as usize)},
-//             _ => Object::null(),
-//         }
-//
-//     }
-// }
+mod indexable {
+    use crate::object::Object;
+    use crate::class_ids::{ARRAY_CLASS_ID, TUPLE_CLASS_ID, INT_CLASS_ID};
+
+    #[inline(always)]
+    #[export_name = "evolve.intrinsic2.get"]
+    fn evolve_intrinsic_get(value: Object, index: Object) -> Object {
+        if index.tag() != INT_CLASS_ID as u64 {
+            return Object::intrinsic_fail();
+        }
+
+        match value.class_id() {
+            TUPLE_CLASS_ID => { value.tuple_get(index.extract_i64() as usize)},
+            ARRAY_CLASS_ID => { value.array_get(index.extract_i64() as usize)},
+            _ => Object::intrinsic_fail(),
+        }
+    }
+}
 
 mod closure {
     use crate::class_ids::CLOSURE_CLASS_ID;

--- a/evolve_inner_core/src/mem.rs
+++ b/evolve_inner_core/src/mem.rs
@@ -52,7 +52,7 @@ unsafe fn evolve_mem_load_i32(ptr: Ptr, offset: isize) -> i32 {
 /// # Safety
 /// caller has to verify this is safe location to read/load from
 #[export_name = "evolve.mem.load.object"]
-pub unsafe fn evolve_mem_load_object(ptr: Ptr, offset: isize) -> Object {
+unsafe fn evolve_mem_load_object(ptr: Ptr, offset: isize) -> Object {
     evolve_mem_gep::<Object>(ptr, offset).read()
 }
 

--- a/evolve_outer_core/src/array.rs
+++ b/evolve_outer_core/src/array.rs
@@ -2,16 +2,6 @@ use evolve_inner_core::array::{adjusted_index, EvolveArray};
 use evolve_inner_core::object::Object;
 
 #[no_mangle]
-fn evolve_array_size(array: &EvolveArray) -> usize {
-    array.len()
-}
-
-#[no_mangle]
-fn evolve_array_capacity(array: &EvolveArray) -> usize {
-    array.capacity()
-}
-
-#[no_mangle]
 fn evolve_array_mut_reserve(array: &mut EvolveArray, capacity: usize) {
     array.reserve(capacity);
 }

--- a/evolve_outer_core/src/array.rs
+++ b/evolve_outer_core/src/array.rs
@@ -116,6 +116,4 @@ mod tests {
 
         assert_eq!(Object::from(42), b);
     }
-
-
 }

--- a/evolve_outer_core/src/array.rs
+++ b/evolve_outer_core/src/array.rs
@@ -117,18 +117,5 @@ mod tests {
         assert_eq!(Object::from(42), b);
     }
 
-    #[test]
-    fn test_new() {
-        let a = evolve_array_literal(10);
-        assert_eq!(10, a.capacity());
-        assert_eq!(0, a.len());
-        assert_eq!(10, evolve_array_capacity(a));
-        assert_eq!(0, evolve_array_size(a));
 
-        let a = evolve_array_literal(0);
-        assert_eq!(8, a.capacity());
-        assert_eq!(0, a.len());
-        assert_eq!(8, evolve_array_capacity(a));
-        assert_eq!(0, evolve_array_size(a));
-    }
 }


### PR DESCRIPTION
- move small array functions from outer to inner
- re-enable intrinsic get
- remove unnecessary `pub`